### PR TITLE
docs: recommend Streamable HTTP instead of SSE

### DIFF
--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_tool.py
@@ -758,7 +758,23 @@ class MCPTool(Tool):
     - The JSON contains the structured response from the MCP server
     - Use json.loads() to parse the response into a dictionary
 
-    Example using HTTP:
+    Example using Streamable HTTP:
+    ```python
+    import json
+    from haystack_integrations.tools.mcp import MCPTool, StreamableHttpServerInfo
+    
+    # Create tool instance
+    tool = MCPTool(
+        name="multiply",
+        server_info=StreamableHttpServerInfo(url="http://localhost:8000/mcp")
+    )
+    
+    # Use the tool and parse result
+    result_json = tool.invoke(a=5, b=3)
+    result = json.loads(result_json)
+    ```
+
+    Example using SSE (deprecated):
     ```python
     import json
     from haystack.tools import MCPTool, SSEServerInfo

--- a/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
+++ b/integrations/mcp/src/haystack_integrations/tools/mcp/mcp_toolset.py
@@ -33,7 +33,7 @@ class MCPToolset(Toolset):
     access to its tools.
 
     MCPToolset dynamically discovers and loads all tools from any MCP-compliant server,
-    supporting both network-based SSE connections and local process-based stdio connections.
+    supporting both network-based streaming connections (Streamable HTTP, SSE) and local process-based stdio connections.
     This dual connectivity allows for integrating with both remote and local MCP servers.
 
     Example using MCPToolset in a Haystack Pipeline:
@@ -86,7 +86,19 @@ class MCPToolset(Toolset):
     print(result["response_llm"]["replies"][0].text)
     ```
 
-    You can also use the toolset via MCP SSE to talk to remote servers:
+    You can also use the toolset via Streamable HTTP to talk to remote servers:
+    ```python
+    from haystack_integrations.tools.mcp import MCPToolset, StreamableHttpServerInfo
+
+    # Create the toolset with streamable HTTP connection
+    toolset = MCPToolset(
+        server_info=StreamableHttpServerInfo(url="http://localhost:8000/mcp"),
+        tool_names=["multiply"]  # Optional: only include specific tools
+    )
+    # Use the toolset as shown in the pipeline example above
+    ```
+    
+    Example using SSE (deprecated):
     ```python
     from haystack_integrations.tools.mcp import MCPToolset, SSEServerInfo
     from haystack.components.tools import ToolInvoker


### PR DESCRIPTION
### Related Issues

- fixes #2337

### Proposed Changes:

Update docs for MCPTool and MCPToolset to mention, that SSE is deprecated.

### How did you test it?

Manual

### Notes for the reviewer

No functionality, just comment

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack-core-integrations/blob/main/CODE_OF_CONDUCT.md)
- I have updated the related issue with new insights and changes
- ~~I added unit tests~~  and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
